### PR TITLE
chore: Add a basic PR template (ARCH-66)

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -26,7 +26,7 @@
 - [ ] I have performed a self-review of my own code
 - [ ] I have made corresponding changes to the documentation
 - [ ] I have merged the latest changes from `main`
-- [ ] CI is Green :checkmark:
+- [ ] CI is Green ✅ 
 
 ## Notes
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+## Why?
+
+( Please include a rationale for the changes and the related issue, providing any relevant motivation and context. )
+
+( Please include a link to the Linear ticket(s). If there is no ticket associated, explain why. )
+( e.g. [ARCH-66 : chore: Create a standard PR Template](https://linear.app/archipelago-ai/issue/ARCH-66/chore-create-a-standard-pr-template) )
+
+## This PR
+
+( Please summarize the changes in this PR, using plain English wherever possible. )
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+## Screenshots (if applicable)
+
+## Testing
+
+( Please describe the tests that you ran to verify your changes. Consider unit, integration, and functional (manual) testing. Ideally, provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Not all changes can be or need to be tested. If so, please write "N/A because <reason>" )
+
+
+## Checklist:
+
+- [ ] I have performed a self-review of my own code
+- [ ] I have made corresponding changes to the documentation
+- [ ] I have merged the latest changes from `main`
+- [ ] CI is Green :checkmark:
+
+## Notes
+
+( Add any other context about the problem, solution, or future considerations here. )

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -25,7 +25,6 @@
 
 - [ ] I have performed a self-review of my own code
 - [ ] I have made corresponding changes to the documentation
-- [ ] I have merged the latest changes from `main`
 - [ ] CI is Green ✅ 
 
 ## Notes


### PR DESCRIPTION
## Why?

When a new PR is up for review, we want it to be easy to thoroughly explain it, without much manual effort.

[ARCH-66 : chore: Create a standard PR Template](https://linear.app/archipelago-ai/issue/ARCH-66/chore-create-a-standard-pr-template)

## This PR

- Creates a global PR template, on which the notes of this PR itself are based

## Screenshots (if applicable)

N/A

## Testing

Not possible. After this lands, the next PR created in any repository should get this template automatically.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- (N/A) I have merged the latest changes from `main`
- (N/A) CI is Green ✅ 